### PR TITLE
Add Red Hat OpenShift and ACM integration documentation

### DIFF
--- a/docs/grafana/index.md
+++ b/docs/grafana/index.md
@@ -1,10 +1,12 @@
-Example Grafana dashboards, provided as is, are hosted on [grafana.com](https://grafana.com/orgs/hpestorage/dashboards).
+# Grafana
+
+Example Grafana dashboards, provided as is, are hosted on [grafana.com](https://grafana.com/orgs/hpestorage/dashboards). Container orchestrator specific instructions to enable these dashboards are available below.
+
+[TOC]
 
 ## Red Hat Advanced Cluster Management
 
 [Red Hat Advanced Cluster Management](https://www.redhat.com/en/technologies/management/advanced-cluster-management) (ACM) includes an Observability component that provides multi-cluster monitoring with a built-in Grafana instance. Custom dashboards can be loaded into this Grafana instance via Kubernetes `ConfigMap` resources. The dashboards hosted on grafana.com require several modifications to work correctly in this environment.
-
-[TOC]
 
 ### Dashboard ConfigMap
 

--- a/docs/grafana/index.md
+++ b/docs/grafana/index.md
@@ -1,1 +1,80 @@
 Example Grafana dashboards, provided as is, are hosted on [grafana.com](https://grafana.com/orgs/hpestorage/dashboards).
+
+## Red Hat Advanced Cluster Management
+
+[Red Hat Advanced Cluster Management](https://www.redhat.com/en/technologies/management/advanced-cluster-management) (ACM) includes an Observability component that provides multi-cluster monitoring with a built-in Grafana instance. Custom dashboards can be loaded into this Grafana instance via Kubernetes `ConfigMap` resources. The dashboards hosted on grafana.com require several modifications to work correctly in this environment.
+
+[TOC]
+
+### Dashboard ConfigMap
+
+ACM Grafana discovers custom dashboards from `ConfigMap` resources in the `open-cluster-management-observability` namespace that carry the `grafana-custom-dashboard: "true"` label. The dashboard JSON is stored as a data key ending in `.json`.
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hpe-array-exporter-dashboard
+  namespace: open-cluster-management-observability
+  labels:
+    cluster.open-cluster-management.io/backup: ""
+    grafana-custom-dashboard: "true"
+data:
+  hpe-exporter-dashboard.json: |
+    {
+      # Dashboard JSON content goes here
+    }
+```
+
+### Adapting Grafana.com Dashboards
+
+Dashboards exported from grafana.com include sections and settings that are not compatible with ACM Grafana. The following modifications are required when wrapping a grafana.com dashboard export into a `ConfigMap`.
+
+**Remove export-only sections.** The `__inputs` and `__requires` sections at the top of the dashboard JSON are used during manual Grafana UI imports and serve no purpose in a `ConfigMap`-based deployment. These sections should be removed entirely.
+
+**Fix datasource references.** Grafana.com exports reference a datasource variable such as `${DS_PROMETHEUS}` that relies on the `__inputs` substitution mechanism. This substitution does not occur when the dashboard is loaded via a `ConfigMap`. All datasource references must be replaced with an explicit object reference.
+
+Replace any occurrence of `"datasource": null` or `"datasource": "${DS_PROMETHEUS}"` with:
+
+```json
+"datasource": {"type": "prometheus", "uid": "default"}
+```
+
+**Update annotation datasource.** The annotation datasource `"datasource": "-- Grafana --"` is a deprecated string format. Replace it with the object format:
+
+```json
+"datasource": {"type": "datasource", "uid": "grafana"}
+```
+
+**Update schema version.** Grafana.com exports may use an older `schemaVersion`. Update the value to match the version supported by the ACM Grafana instance (e.g. `39`).
+
+**Remove stale fields.** Fields such as `gnetId`, `iteration`, and `"style": "dark"` are grafana.com export artifacts and can be removed.
+
+!!! important
+    The dashboard metric names must match the platform-specific prefix used by the exporter. The exporter uses prefixes such as `hpealletrastoragemp_`, `hpealletra9000_`, `hpeprimera_`, `hpe3par_`, `hpealletra6000_`, and `hpenimble_` rather than a generic `hpe_` prefix. All PromQL expressions in the dashboard must be updated to use the correct prefix for the target storage platform. Refer to the [Metrics](../metrics/index.md) page for the full list of metric names per platform.
+
+### Metrics Allowlist
+
+ACM Observability collects metrics from managed clusters and forwards them to the hub cluster. Only metrics included in a custom allowlist `ConfigMap` are collected. The exporter runs as a user workload, so its metrics must be added to the `uwl_metrics_list.yaml` section of the allowlist rather than the `metrics_list.yaml` section.
+
+!!! important
+    The `metrics_list.yaml` section is for metrics scraped by the platform Prometheus instance (in the `openshift-monitoring` namespace). The `uwl_metrics_list.yaml` section is for metrics scraped by the User Workload Monitoring Prometheus instance. The exporter is a user workload and its metrics are scraped by the latter. Placing entries in the wrong section results in no data being collected.
+
+The following example adds a match rule for HPE Alletra Storage MP B10000 metrics to the allowlist `ConfigMap` on the hub cluster.
+
+```yaml
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: observability-metrics-custom-allowlist
+  namespace: open-cluster-management-observability
+data:
+  uwl_metrics_list.yaml: |
+    matches:
+    - __name__=~"hpealletrastoragemp_.*"
+```
+
+!!! note
+    The match pattern must correspond to the metric prefix used by the exporter for the target storage platform. Refer to the [Metrics](../metrics/index.md) page for the metric names and prefixes per platform.

--- a/docs/integration/index.md
+++ b/docs/integration/index.md
@@ -90,3 +90,47 @@ spec:
     It may be desirable for metrics from the exporter to include a label identifying the storage system from which they are collected.  In this example, the `targetLabels` configuration refers to an `array` label that must have been included in the Service object.
 
 A ServiceMonitor example can also be found in the [sample YAML files](https://github.com/hpe-storage/co-deployments/tree/master/yaml/array-exporter).
+
+## Red Hat OpenShift
+
+When running the exporter on Red Hat OpenShift, User Workload Monitoring can be used to scrape the exporter metrics. The exporter is a user-deployed application and its metrics are collected by the User Workload Monitoring Prometheus instance rather than the platform Prometheus instance.
+
+### Enabling User Workload Monitoring
+
+User Workload Monitoring is not enabled by default on OpenShift. It must be enabled by an administrator before a `ServiceMonitor` in a user namespace can be discovered.
+
+!!! important
+    User Workload Monitoring must be enabled on the OpenShift cluster for the exporter `ServiceMonitor` to be discovered. Refer to the [Red Hat OpenShift documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/monitoring/configuring-user-workload-monitoring) for instructions on enabling User Workload Monitoring.
+
+### Using a ServiceMonitor
+
+On OpenShift, the User Workload Monitoring Prometheus instance automatically discovers `ServiceMonitor` resources in user namespaces. The `k8s-app` and `release` labels used in the upstream Kubernetes examples are not required.
+
+#### ServiceMonitor Example
+
+```yaml
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hpe-array-exporter
+  namespace: hpe-storage
+spec:
+  endpoints:
+    - port: http-metrics
+      scheme: http
+      interval: 60s
+  selector:
+    matchLabels:
+      app: hpe-array-exporter
+  namespaceSelector:
+    matchNames:
+      - hpe-storage
+  # Corresponding labels on the Array Exporter service are added to
+  # the scraped metrics; customize as desired
+  targetLabels:
+    - array
+```
+
+!!! note
+    The `ServiceMonitor` is placed in the same namespace as the exporter (`hpe-storage`). OpenShift's User Workload Monitoring Prometheus discovers it automatically without additional label selectors.


### PR DESCRIPTION
## Summary

- Add Red Hat OpenShift User Workload Monitoring section to the Prometheus Integration page, including a simplified ServiceMonitor example
- Add Red Hat Advanced Cluster Management (ACM) Observability section to the Grafana Dashboards page, covering dashboard ConfigMap deployment, grafana.com dashboard adaptation steps, and metrics allowlist configuration

## Details

The HPE Storage Array Exporter documentation currently has no coverage for Red Hat OpenShift or ACM environments. These additions document several non-obvious integration requirements discovered during deployment:

- The exporter is a user workload on OpenShift, requiring User Workload Monitoring (not platform monitoring)
- The upstream ServiceMonitor labels (`k8s-app`, `release`) are not needed on OpenShift
- ACM Grafana dashboards loaded via ConfigMap require datasource, schema version, and annotation format changes compared to grafana.com exports
- ACM's metrics allowlist distinguishes between platform (`metrics_list.yaml`) and user workload (`uwl_metrics_list.yaml`) metrics — the exporter metrics must be in the latter
- Dashboard PromQL expressions must use platform-specific metric prefixes rather than a generic `hpe_` prefix

## Test plan

- [ ] Verify `mkdocs serve` renders the new sections correctly
- [ ] Verify admonitions, code blocks, and cross-references render properly
- [ ] Review heading hierarchy integrates cleanly with existing TOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)